### PR TITLE
CI: Skip code coverage report

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ namespace :coverage do
 end
 
 task :spec do
-  Rake::Task[:'coverage:report'].invoke unless ENV['TRAVIS_RUBY_VERSION']
+  Rake::Task[:'coverage:report'].invoke unless ENV['CI']
 end
 
 task :default => :spec


### PR DESCRIPTION
This PR avoids errors in CI by harmonizing the current code with GH Actions.

<details>

<summary>This was the output that this PR avoids</summary>

Coverage report generated for RSpec to /home/runner/work/paypal-express/paypal-express/coverage.
Line Coverage: 98.58% (554 / 562)
/opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Couldn't find a suitable web browser!

Set the BROWSER environment variable to your desired browser.

Warning: program returned non-zero exit code #256
/usr/bin/open: 882: www-browser: not found
/usr/bin/open: 882: links2: not found
/usr/bin/open: 882: elinks: not found
/usr/bin/open: 882: links: not found
/usr/bin/open: 882: lynx: not found
/usr/bin/open: 882: w3m: not found
xdg-open: no method available for opening '/home/runner/work/paypal-express/paypal-express/coverage/index.html'

</details>